### PR TITLE
lib/cuav_region.py: fix bug, abs(x) is never < 0

### DIFF
--- a/cuav/lib/cuav_region.py
+++ b/cuav/lib/cuav_region.py
@@ -85,7 +85,7 @@ def array_compactness(im):
         P = P - outer(wmean,wmean);
 
         det = abs(linalg.det(P))
-        if (det < 0):
+        if (det == 0):
                 return 0.0
         v = linalg.eigvalsh(P)
         v = abs(v)


### PR DESCRIPTION
cause of occasional divide by zero errors