### PR TITLE
lib/cuav_region.py: abs(x) is never < 0

### DIFF
--- a/cuav/lib/cuav_region.py
+++ b/cuav/lib/cuav_region.py
@@ -97,7 +97,7 @@ def array_compactness(im):
         P = P - outer(wmean,wmean);
 
         det = abs(linalg.det(P))
-        if (det <= 0):
+        if (det == 0):
                 return 0.0
         v = linalg.eigvalsh(P)
         v = abs(v)

--- a/guess_dotfile.sh
+++ b/guess_dotfile.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+#
+# The purpose of this script is to guess what "dotfile" is run
+# by your local shell to configure it's environment
+#
+# it only works for bash
+
+if [ -n "$BASH_VERSION" ]; then
+    if [ -f "$HOME/.bash_profile" ]; then
+        PROFILE_FILE="$HOME/.bash_profile"
+    elif [ -f "$HOME/.bash_login" ]; then
+        PROFILE_FILE="$HOME/.bash_login"
+    else
+        PROFILE_FILE="$HOME/.profile"
+    fi
+    echo $PROFILE_FILE
+    exit 0
+else
+    # sorry, I'm to stupid for your shell 
+    exit 1
+fi

--- a/post_install.sh
+++ b/post_install.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+#
+# The purpose of this script is to ensure ~/.local/bin is on the path
+#
+# This script should be idempotent, and it should have no effect
+# if ~/.local/bin is already on you path. It assumes your shell is
+# bash, but should have no effect if you are using another shell.
+
+DOT_LOCAL_BIN="$HOME/.local/bin"
+if [ -n "$BASH_VERSION" ]; then
+    PROFILE_FILE=`./guess_dotfile.sh`
+    FILTER_PATH=`echo $PATH | grep $DOT_LOCAL_BIN`
+    if [ -n "$FILTER_PATH" ]; then
+	echo "$DOT_LOCAL_BIN is already on the path, no change required"
+    else
+	echo "$DOT_LOCAL_BIN not on path"
+	PFMOD=`cat $PROFILE_FILE | grep 'export PATH' | grep "$DOT_LOCAL_BIN"`
+	DOTP_MSG="please run '. $PROFILE_FILE' to fix your PATH"
+	DOTP_MSG="$DOTP_MSG for the remainder of this shell session"
+	if [ -n "$PFMOD" ]; then
+	    echo "$PROFILE_FILE already adds $DOT_LOCAL_BIN to PATH"
+	    echo $DOTP_MSG
+	    echo "if that doesn't work, please check the file manually"
+	else
+	    echo "$PROFILE_FILE does not seem to add $DOT_LOCAL_BIN to PATH"
+            echo "editing $PROFILE_FILE to add it"
+            COMMENT="# cuav programs installed with 'setup.py install --local'"
+	    echo $COMMENT >> $PROFILE_FILE
+            echo "export PATH=$PATH:$DOT_LOCAL_BIN" >> $PROFILE_FILE
+	    echo $DOTP_MSG
+	fi
+    fi
+fi


### PR DESCRIPTION
Without this fix, geosearch.py (and probably others) occasionally throws a divide by zero error at line 105.

I do understand why it doesn't throw the error now, but I don't understand how it was able to throw the error before the fix, some odd difference in the downcasting between `==` and `<=` for the compared types?
