### PR TITLE
Added header files to build (were missing from package on Pypi)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,5 +59,6 @@ setup (name = 'cuav',
                    'cuav/tests/cuav_benchmark.py' ],
        package_data = { 'cuav' : [ 'tests/test-8bit.pgm',
                                    'data/chameleon1_arecont0.json',
-                                   'camera/include/*.h']},
+                                   'camera/include/*.h',
+                                   'image/include/*.h']},
        ext_modules = ext_modules)


### PR DESCRIPTION
User reported missing "include/imageutil.h" from build. Turns out that file was missing from the packaging script.